### PR TITLE
Allow to run embedded mongo on a dynamic port

### DIFF
--- a/src/main/java/io/vertx/ext/embeddedmongo/EmbeddedMongoVerticle.java
+++ b/src/main/java/io/vertx/ext/embeddedmongo/EmbeddedMongoVerticle.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 public class EmbeddedMongoVerticle extends AbstractVerticle {
 
   private MongodExecutable exe;
+  private int actualPort;
 
   @Override
   public void start() throws Exception {
@@ -54,11 +55,11 @@ public class EmbeddedMongoVerticle extends AbstractVerticle {
 
     JsonObject config = context.config();
 
-    int port = config.getInteger("port");
+    int port = config.getInteger("port", 0);
 
     IMongodConfig embeddedConfig = new MongodConfigBuilder().
       version(Version.Main.PRODUCTION).
-      net(new Net(port, Network.localhostIsIPv6())).
+      net(port == 0 ? new Net() : new Net(port, Network.localhostIsIPv6())).
       build();
 
     Logger logger = (Logger) new SLF4JLogDelegateFactory()
@@ -70,6 +71,12 @@ public class EmbeddedMongoVerticle extends AbstractVerticle {
 
     exe = MongodStarter.getInstance(runtimeConfig).prepare(embeddedConfig);
     exe.start();
+
+    actualPort = embeddedConfig.net().getPort();
+  }
+
+  public int actualPort() {
+    return actualPort;
   }
 
   @Override

--- a/src/test/java/io/vertx/ext/embeddedmongo/test/EmbeddedMongoVerticleTest.java
+++ b/src/test/java/io/vertx/ext/embeddedmongo/test/EmbeddedMongoVerticleTest.java
@@ -16,7 +16,10 @@
 
 package io.vertx.ext.embeddedmongo.test;
 
+import io.vertx.core.DeploymentOptions;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.embeddedmongo.EmbeddedMongoVerticle;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -36,11 +39,56 @@ public class EmbeddedMongoVerticleTest extends VertxTestBase {
     // Not really sure what to test here apart from start and stop
     vertx.deployVerticle("service:io.vertx.vertx-mongo-embedded-db", onSuccess(deploymentID -> {
       assertNotNull(deploymentID);
-      vertx.undeploy(deploymentID, onSuccess(v -> {
-        assertNull(v);
-        testComplete();
-      }));
+      undeploy(deploymentID);
     }));
     await();
+  }
+
+  @Test
+  public void testConfiguredPort() {
+    EmbeddedMongoVerticle mongo = new EmbeddedMongoVerticle();
+    vertx.deployVerticle(mongo, createOptions(7533), onSuccess(deploymentID -> {
+      assertNotNull(deploymentID);
+      assertEquals(7533, mongo.actualPort());
+      undeploy(deploymentID);
+    }));
+    await();
+  }
+
+  @Test
+  public void testRandomPort() {
+    EmbeddedMongoVerticle mongo = new EmbeddedMongoVerticle();
+    vertx.deployVerticle(mongo, createOptions(0), onSuccess(deploymentID -> {
+      assertNotNull(deploymentID);
+      assertNotSame(0, mongo.actualPort());
+      undeploy(deploymentID);
+    }));
+    await();
+  }
+
+  @Test
+  public void testRandomPortNoConfig() {
+    EmbeddedMongoVerticle mongo = new EmbeddedMongoVerticle();
+    vertx.deployVerticle(mongo, createEmptyOptions(), onSuccess(deploymentID -> {
+      assertNotNull(deploymentID);
+      assertNotSame(0, mongo.actualPort());
+      undeploy(deploymentID);
+    }));
+    await();
+  }
+
+  private DeploymentOptions createOptions(int port) {
+    return createEmptyOptions().setConfig(new JsonObject().put("port", port));
+  }
+
+  private DeploymentOptions createEmptyOptions() {
+    return new DeploymentOptions().setWorker(true);
+  }
+
+  private void undeploy(String deploymentID) {
+    vertx.undeploy(deploymentID, onSuccess(v -> {
+      assertNull(v);
+      testComplete();
+    }));
   }
 }


### PR DESCRIPTION
This change allows to run mongo on a random available port instead of a fixed (configured) one so tests using it don't depend on a specific port to be available and can be run in parallel.