### PR TITLE
Support versions of Mongo newer than 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@
 
 This enables you to start up an embedded MongoDB instance by deploying a verticle. Useful for tests that
 require MongoDB
+
+To specify a specific Mongo `version`, use this configuration in the `DeploymentOptions` of the verticle:
+
+```$java
+new DeploymentOptions()
+  .setConfig(new JsonObject()
+     // Prefer a port that doesn't conflict with background mongod
+     .put("port", 27018) 
+     // Prefer a version that 100% works on Windows
+     .put("version", "3.4.2"))
+```

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ new DeploymentOptions()
      // Prefer a port that doesn't conflict with background mongod
      .put("port", 27018) 
      // Prefer a version that 100% works on Windows
-     .put("version", "3.4.2"))
+     .put("version", "3.4.3"))
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>1.50.3</version>
+      <version>2.0.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/src/main/java/io/vertx/ext/embeddedmongo/EmbeddedMongoVerticle.java
+++ b/src/main/java/io/vertx/ext/embeddedmongo/EmbeddedMongoVerticle.java
@@ -27,16 +27,24 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.runtime.Network;
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.SLF4JLogDelegateFactory;
 import org.slf4j.Logger;
 
 /**
  * This verticle wraps an embedded MongoDB instance.
- *
+ * <p>
+ * The following {@link Context#config()} options are supported:
+ * <ul>
+ *     <li>"port" (int, default 0): The port to host Mongo on, or 0 for any port.</li>
+ *     <li>"version" (String, default "3.4.3"): The Mongo version, up to 3.6.2. Note 3.4.3 is the last version to work
+ *         correctly on Windows.</li>
+ * </ul>
+ * <p>
  * It's useful if you have an application that uses MongoDB and you want to write unit tests for it
  * that run without having to manually set-up a MongoDB.
- *
+ * <p>
  * Just deploy the verticle before your test.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -56,9 +64,15 @@ public class EmbeddedMongoVerticle extends AbstractVerticle {
     JsonObject config = context.config();
 
     int port = config.getInteger("port", 0);
+    // mongod version 3.4.3 is the last to work properly on Windows 10, so this is the default version for this package
+    // See https://jira.mongodb.org/browse/SERVER-26028
+    String version = config.getString("version", "3.4.3");
+    // The flapdoodle enum names are unconventional
+    version = "V" + version.replace('.', '_');
+    final Version versionEnum = Version.valueOf(version);
 
     IMongodConfig embeddedConfig = new MongodConfigBuilder().
-      version(Version.Main.PRODUCTION).
+      version(versionEnum).
       net(port == 0 ? new Net() : new Net(port, Network.localhostIsIPv6())).
       build();
 

--- a/src/main/resources/io.vertx.vertx-mongo-embedded-db.json
+++ b/src/main/resources/io.vertx.vertx-mongo-embedded-db.json
@@ -4,7 +4,8 @@
   "options": {
     "worker": true,
     "config": {
-      "port": 27018 // We choose this so as not to clash with default port 27017 of real Mongo
+      "port": 27018,
+      "version": "3.4.3"
     }
   }
 }

--- a/src/main/resources/io.vertx.vertx-mongo-embedded-db.json
+++ b/src/main/resources/io.vertx.vertx-mongo-embedded-db.json
@@ -4,7 +4,7 @@
   "options": {
     "worker": true,
     "config": {
-      "port": 27018,
+      "port": 27018, // We choose this so as not to clash with default port 27017 of real Mongo
       "version": "3.4.3"
     }
   }

--- a/src/test/java/io/vertx/ext/embeddedmongo/test/EmbeddedMongoVerticleTest.java
+++ b/src/test/java/io/vertx/ext/embeddedmongo/test/EmbeddedMongoVerticleTest.java
@@ -31,7 +31,7 @@ public class EmbeddedMongoVerticleTest extends VertxTestBase {
   @Override
   public VertxOptions getOptions() {
     // It can take some time to download the first time!
-    return new VertxOptions().setMaxWorkerExecuteTime(30 * 60 * 1000);
+    return new VertxOptions().setMaxWorkerExecuteTime(30 * 60 * 1000).setWarningExceptionTime(30 * 60* 1000);
   }
 
   @Test

--- a/src/test/java/io/vertx/ext/embeddedmongo/test/EmbeddedMongoVerticleTest.java
+++ b/src/test/java/io/vertx/ext/embeddedmongo/test/EmbeddedMongoVerticleTest.java
@@ -31,7 +31,7 @@ public class EmbeddedMongoVerticleTest extends VertxTestBase {
   @Override
   public VertxOptions getOptions() {
     // It can take some time to download the first time!
-    return new VertxOptions().setMaxWorkerExecuteTime(30 * 60 * 1000).setWarningExceptionTime(30 * 60* 1000);
+    return new VertxOptions().setMaxWorkerExecuteTime(30 * 60 * 1000).setWarningExceptionTime(30 * 60 * 1000);
   }
 
   @Test
@@ -56,6 +56,27 @@ public class EmbeddedMongoVerticleTest extends VertxTestBase {
   }
 
   @Test
+  public void testConfiguredVersion() {
+    EmbeddedMongoVerticle mongo = new EmbeddedMongoVerticle();
+    vertx.deployVerticle(mongo, createOptions(7533, "3.0.0"), onSuccess(deploymentID -> {
+      assertNotNull(deploymentID);
+      assertEquals(7533, mongo.actualPort());
+      undeploy(deploymentID);
+    }));
+    await();
+  }
+
+  @Test
+  public void testNonexistentVersionFails() {
+    EmbeddedMongoVerticle mongo = new EmbeddedMongoVerticle();
+    vertx.deployVerticle(mongo, createOptions(7533, "ninethousand"), onFailure(throwable -> {
+      testComplete();
+    }));
+    await();
+  }
+
+
+  @Test
   public void testRandomPort() {
     EmbeddedMongoVerticle mongo = new EmbeddedMongoVerticle();
     vertx.deployVerticle(mongo, createOptions(0), onSuccess(deploymentID -> {
@@ -78,7 +99,11 @@ public class EmbeddedMongoVerticleTest extends VertxTestBase {
   }
 
   private DeploymentOptions createOptions(int port) {
-    return createEmptyOptions().setConfig(new JsonObject().put("port", port));
+    return createOptions(port, "3.4.3");
+  }
+
+  private DeploymentOptions createOptions(int port, String version) {
+    return createEmptyOptions().setConfig(new JsonObject().put("port", port).put("version", version));
   }
 
   private DeploymentOptions createEmptyOptions() {

--- a/src/test/java/io/vertx/ext/embeddedmongo/test/EmbeddedMongoVerticleTest.java
+++ b/src/test/java/io/vertx/ext/embeddedmongo/test/EmbeddedMongoVerticleTest.java
@@ -28,10 +28,13 @@ import org.junit.Test;
  */
 public class EmbeddedMongoVerticleTest extends VertxTestBase {
 
+  public static final long MAX_WORKER_EXECUTE_TIME = 30 * 60 * 1000L;
+  public static final int TEST_PORT = 7533;
+
   @Override
   public VertxOptions getOptions() {
     // It can take some time to download the first time!
-    return new VertxOptions().setMaxWorkerExecuteTime(30 * 60 * 1000).setWarningExceptionTime(30 * 60 * 1000);
+    return new VertxOptions().setMaxWorkerExecuteTime(MAX_WORKER_EXECUTE_TIME);
   }
 
   @Test
@@ -47,20 +50,20 @@ public class EmbeddedMongoVerticleTest extends VertxTestBase {
   @Test
   public void testConfiguredPort() {
     EmbeddedMongoVerticle mongo = new EmbeddedMongoVerticle();
-    vertx.deployVerticle(mongo, createOptions(7533), onSuccess(deploymentID -> {
+    vertx.deployVerticle(mongo, createOptions(TEST_PORT), onSuccess(deploymentID -> {
       assertNotNull(deploymentID);
-      assertEquals(7533, mongo.actualPort());
+      assertEquals(TEST_PORT, mongo.actualPort());
       undeploy(deploymentID);
     }));
     await();
   }
 
   @Test
-  public void testConfiguredVersion() {
+  public void testDeploysSpecificVersionWithoutErrors() {
     EmbeddedMongoVerticle mongo = new EmbeddedMongoVerticle();
-    vertx.deployVerticle(mongo, createOptions(7533, "3.0.0"), onSuccess(deploymentID -> {
+    vertx.deployVerticle(mongo, createOptions(TEST_PORT, "3.0.0"), onSuccess(deploymentID -> {
       assertNotNull(deploymentID);
-      assertEquals(7533, mongo.actualPort());
+      assertEquals(TEST_PORT, mongo.actualPort());
       undeploy(deploymentID);
     }));
     await();
@@ -69,7 +72,7 @@ public class EmbeddedMongoVerticleTest extends VertxTestBase {
   @Test
   public void testNonexistentVersionFails() {
     EmbeddedMongoVerticle mongo = new EmbeddedMongoVerticle();
-    vertx.deployVerticle(mongo, createOptions(7533, "ninethousand"), onFailure(throwable -> {
+    vertx.deployVerticle(mongo, createOptions(TEST_PORT, "ninethousand"), onFailure(throwable -> {
       testComplete();
     }));
     await();


### PR DESCRIPTION
(3.6.2 isn't specifically tested here because Windows won't run it anyway)